### PR TITLE
openssl11: also prioritize chacha20 for bcm675x models which lack AES…

### DIFF
--- a/release/src/router/Makefile
+++ b/release/src/router/Makefile
@@ -7208,7 +7208,7 @@ openssl-1.1/Makefile:
 	-O2 -ffunction-sections -fdata-sections -Wl,--gc-sections \
 	shared $(OPENSSL_CIPHERS) no-err no-async --api=1.0.0 \
 	no-aria no-sm2 no-sm3 no-sm4 \
-	$(if $(filter y,$(HND_ROUTER)),,-DOPENSSL_PREFER_CHACHA_OVER_GCM)
+	$(if $(filter 4908,$(BCM_CHIP)),,-DOPENSSL_PREFER_CHACHA_OVER_GCM)
 	-@$(MAKE) -C openssl-1.1 depend clean
 	@touch $@
 


### PR DESCRIPTION
… acceleration